### PR TITLE
fixes call bin of grunt-cli on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (pth) {
 		pth = process.cwd();
 	}
 
-	var gruntBinPath = require.resolve('grunt-cli/bin/grunt');
+	var gruntBinPath = (process.platform === 'win32') ? require.resolve('.bin/grunt.cmd') : require.resolve('.bin/grunt');
 
 	return pify(childProcess.execFile, Promise)(gruntBinPath, ['--help', '--no-color'], {cwd: pth})
 		.then(function (stdout) {


### PR DESCRIPTION
NodeJS can not run the script with path to the JS file from the bin
folder (which was, grunt-cli/bin/grunt).

But showing the path to the CMD script it runs normally.

For \* nix systems went the way of an SH script.
